### PR TITLE
Update FOSSBilling compatibility

### DIFF
--- a/Controller/Admin.php
+++ b/Controller/Admin.php
@@ -11,8 +11,20 @@
 
 namespace Box\Mod\Servicepterodactyl\Controller;
 
-class Admin extends \FOSSBilling\Controller
+class Admin implements \FOSSBilling\InjectionAwareInterface
 {
+    protected $di;
+
+    public function setDi(\Pimple\Container|null $di): void
+    {
+        $this->di = $di;
+    }
+
+    public function getDi(): ?\Pimple\Container
+    {
+        return $this->di;
+    }
+
     public function register(\FOSSBilling\Events $hooks): void
     {
         $hooks->on(

--- a/Controller/Client.php
+++ b/Controller/Client.php
@@ -11,8 +11,20 @@
 
 namespace Box\Mod\Servicepterodactyl\Controller;
 
-class Client extends \FOSSBilling\Controller
+class Admin implements \FOSSBilling\InjectionAwareInterface
 {
+    protected $di;
+
+    public function setDi(\Pimple\Container|null $di): void
+    {
+        $this->di = $di;
+    }
+
+    public function getDi(): ?\Pimple\Container
+    {
+        return $this->di;
+    }
+    
     public function register(\FOSSBilling\Events $hooks): void
     {
         $hooks->on(


### PR DESCRIPTION
Updated for the most recent versions of FOSSBilling.  No more `class Admin extends \FOSSBilling\Controller` 
Use `class Admin implements \FOSSBilling\InjectionAwareInterface` instead.